### PR TITLE
Add a couple tests, fix a bug

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -17,6 +17,6 @@ module.exports = function(grunt) {
             options: { commitMessage: 'NPM Release v<%= version %>' }
         }
     });
-
+    
     grunt.registerTask('default', [ 'jshint', 'mochaTest' ]);
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grunt-nunit-runner",
-  "version": "2.0.5",
+  "version": "2.1.0",
   "description": "grunt plugin for running nunit",
   "homepage": "https://github.com/mikeobrien/grunt-nunit-runner",
   "main": "tasks/task.js",

--- a/tasks/nunit.js
+++ b/tasks/nunit.js
@@ -38,6 +38,7 @@ exports.findTestAssemblies = function(files, options) {
 exports.buildCommand = function(assemblies, options) {
 
     var nunit = '';
+    var args = assemblies.map(function(assembly) { return '"' + assembly + '"'; });
 
     if(!options.version || options.version < 3) {
         nunit = options.platform === 'x86' ? 'nunit-console-x86.exe' : 'nunit-console.exe';
@@ -50,8 +51,6 @@ exports.buildCommand = function(assemblies, options) {
     if (options.path) nunit = path.join(options.path, nunit);
 
     nunit = nunit.replace(/\\/g, path.sep);
-
-    var args = assemblies.map(function(assembly) { return '"' + assembly + '"'; });
 
     if (options.run && options.run.length > 0) args.push('/run:"' + options.run.join(',') + '"');
     if (options.runlist) args.push('/runlist:"' + options.runlist + '"');

--- a/test/nunit.spec.js
+++ b/test/nunit.spec.js
@@ -28,4 +28,20 @@ describe('nunit', function() {
 
     });
 
+    it('should detect exe name correctly', function() {
+
+        expect(nunit.buildCommand(['asm.dll'], { version: 3, platform: 'x86' }).path).to.be('nunit3-console.exe');
+        expect(nunit.buildCommand(['asm.dll'], { version: 3, platform: 'x64' }).path).to.be('nunit3-console.exe');
+        expect(nunit.buildCommand(['asm.dll'], { version: 3 }).path).to.be('nunit3-console.exe');
+        
+        expect(nunit.buildCommand(['asm.dll'], { version: 2, platform: 'x86' }).path).to.be('nunit-console-x86.exe');
+        expect(nunit.buildCommand(['asm.dll'], { version: 2, platform: 'x64' }).path).to.be('nunit-console.exe');
+        expect(nunit.buildCommand(['asm.dll'], { version: 2 }).path).to.be('nunit-console.exe');
+        
+        expect(nunit.buildCommand(['asm.dll'], { platform: 'x86' }).path).to.be('nunit-console-x86.exe');
+        expect(nunit.buildCommand(['asm.dll'], { platform: 'x64' }).path).to.be('nunit-console.exe');
+        expect(nunit.buildCommand(['asm.dll'], {}).path).to.be('nunit-console.exe');
+        
+    });
+    
 });


### PR DESCRIPTION
Fixed a bug where passing { version: 3, platform: x86 } would cause a crash.
Also, added tests to detect exe name
